### PR TITLE
.pep8 configuration file +.dir-locals.el for emacs editing.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,5 @@
+;;; Directory Local Variables
+;;; See Info node `(emacs) Directory Variables' for more information.
+
+((python-mode
+  (indent-tabs-mode . t)))

--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,3 @@
+[pep8]
+ignore = W191,E122,E128,E201,E202,E261,E701,E401
+max-line-length = 100


### PR DESCRIPTION
I have added an .dir-locals.el to forcefully  tell emacs that this project uses tabs for indentation. 

I disabled a whole lot of warnings/error from pep8 (W191,E122,E128,E201,E202,E261,E701,E401
)

The following "errors" remains.
 I personally find that these particular style rules increase readability quite a bit. would you merge an pull request which fixes everything below?

```
Statistics:
9       E225 missing whitespace around operator
2       E231 missing whitespace after ','
3       E301 expected 1 blank line, found 0
5       E302 expected 2 blank lines, found 1
5       E303 too many blank lines (2)
4       E502 the backslash is redundant between brackets

Details:
pulseaudio-mixer-cli.py:9:11: E225 missing whitespace around operator
    default=2**16, help='Value to treat as max (default: %(default)s).')
          ^
pulseaudio-mixer-cli.py:41:1: E302 expected 2 blank lines, found 1
def get_bus(srv_addr=None, dont_start=False):
^
pulseaudio-mixer-cli.py:86:42: E231 missing whitespace after ','
    signal.signal(signal.SIGUSR1, lambda sig,frm: loop.quit())
                                         ^
pulseaudio-mixer-cli.py:103:51: E502 the backslash is redundant between brackets
            core.ListenForSignal( 'org.PulseAudio.Core1.{}'\
                                                  ^
pulseaudio-mixer-cli.py:121:1: E302 expected 2 blank lines, found 1
class PAUpdate(Exception): pass
^
pulseaudio-mixer-cli.py:123:1: E302 expected 2 blank lines, found 1
class PAMenu(dict):
^
pulseaudio-mixer-cli.py:136:2: E303 too many blank lines (2)
    def _dbus_failsafe(method):
 ^
pulseaudio-mixer-cli.py:148:2: E301 expected 1 blank line, found 0
    def _name( self, iface, props,
 ^
pulseaudio-mixer-cli.py:149:66: E225 missing whitespace around operator
            _unique_idx=it.chain.from_iterable(it.imap(xrange, it.repeat(2**30))) ):
                                                                 ^
pulseaudio-mixer-cli.py:169:67: E502 the backslash is redundant between brackets
            name = '{} {}'.format( name, re.sub(r'\{([^}]+)\}', r'{}', ext)\
                                                                  ^
pulseaudio-mixer-cli.py:175:2: E303 too many blank lines (2)
    @_dbus_failsafe
 ^
pulseaudio-mixer-cli.py:194:2: E303 too many blank lines (2)
    def refresh(self, soft=True):
 ^
pulseaudio-mixer-cli.py:204:61: E502 the backslash is redundant between brackets
                self.bus.get_object(object_path='/org/pulseaudio/core1')\
                                                            ^
pulseaudio-mixer-cli.py:209:61: E502 the backslash is redundant between brackets
                self.bus.get_object(object_path='/org/pulseaudio/core1')\
                                                            ^
pulseaudio-mixer-cli.py:232:2: E303 too many blank lines (2)
    @_dbus_failsafe
 ^
pulseaudio-mixer-cli.py:278:2: E303 too many blank lines (2)
    def next_key(self, item):
 ^
pulseaudio-mixer-cli.py:279:74: E225 missing whitespace around operator
        try: return (list(it.dropwhile(lambda k: k != item, self)) + list(self)*2)[1]
                                                                         ^
pulseaudio-mixer-cli.py:281:2: E301 expected 1 blank line, found 0
    def prev_key(self, item):
 ^
pulseaudio-mixer-cli.py:284:45: E225 missing whitespace around operator
                reversed(self) )) + list(reversed(self))*2)[1]
                                            ^
pulseaudio-mixer-cli.py:289:2: E301 expected 1 blank line, found 0
    def __reversed__(self): return self.__iter__(reverse=True)
 ^
pulseaudio-mixer-cli.py:301:1: E302 expected 2 blank lines, found 1
def interactive_cli(stdscr, items, border=0):
^
pulseaudio-mixer-cli.py:307:21: E225 missing whitespace around operator
        return size[0] - 2*border, size[1] - 2*border
                    ^
pulseaudio-mixer-cli.py:307:41: E225 missing whitespace around operator
        return size[0] - 2*border, size[1] - 2*border
                                        ^
pulseaudio-mixer-cli.py:323:10: E231 missing whitespace after ','
        for row,item in enumerate(items):
         ^
pulseaudio-mixer-cli.py:328:23: E225 missing whitespace around operator
                bar = bar_caps('#'*bar_fill + '-'*(bar_len-bar_fill))
                      ^
pulseaudio-mixer-cli.py:328:38: E225 missing whitespace around operator
                bar = bar_caps('#'*bar_fill + '-'*(bar_len-bar_fill))
                                     ^
pulseaudio-mixer-cli.py:328:47: E225 missing whitespace around operator
                bar = bar_caps('#'*bar_fill + '-'*(bar_len-bar_fill))
                                              ^
pulseaudio-mixer-cli.py:370:1: E302 expected 2 blank lines, found 1
def reexec():
^

```
