### PR TITLE
Added mute button and key binding.

### DIFF
--- a/pulseaudio-mixer-cli.py
+++ b/pulseaudio-mixer-cli.py
@@ -101,7 +101,7 @@ if not child_pid:
 				('PlaybackStreamRemoved', ft.partial(notify, op='-')) ):
 			bus.add_signal_receiver(sig_handler, sig_name)
 			core.ListenForSignal( 'org.PulseAudio.Core1.{}'\
- 				.format(sig_name), dbus.Array(signature='o') )
+				.format(sig_name), dbus.Array(signature='o') )
 		loop.run()
 
 	# This should never be executed


### PR DESCRIPTION
Either an M or - is displayed after the sink name. Pressing 'm' mutes/unmutes the sink.

I refactored the existing volume specific set/get function names to get_/set_volume and just copied the cache code to my get_/set_mute stuff. It is probably a good idea to make a common structure for this if more is added but this will do and cause less changes to be made.
