### PR TITLE
Fix defaults for STDOUT and Conf.stream_params

### DIFF
--- a/pa-mixer-mk2.py
+++ b/pa-mixer-mk2.py
@@ -20,7 +20,7 @@ class Conf(object):
 	placeholder_media_names = 'audio stream', 'AudioStream', 'Output'
 	overkill_redraw = False # if terminal gets resized often, might cause noticeable flickering
 	verbose = False
-	stream_params = None
+	stream_params = OrderedDict()
 	broken_chars_replace = u'_'
 	focus_default = 'first' # either "first" or "last"
 	focus_new_items = True
@@ -332,7 +332,7 @@ class PAMixerDBusBridge(object):
 					raise
 				subprocess.Popen(
 					['pulseaudio', '--start', '--log-target=syslog'],
-					stdout=open('/dev/null', 'wb'), stderr=STDOUT ).wait()
+					stdout=open('/dev/null', 'wb'), stderr=subprocess.STDOUT ).wait()
 				log.debug('Started new pa-server instance')
 				# from time import sleep
 				# sleep(1) # XXX: still needed?


### PR DESCRIPTION
Provides a workable default for `Conf.stream_params` if a conf file
doesn't exist in the user's home directory. Would crash otherwise.

Thanks for the great script! :+1: 
